### PR TITLE
Rime reads bitmask FcitxKeyState_CapsLock to detect whether caps lock is on

### DIFF
--- a/src/fcitx-rime.c
+++ b/src/fcitx-rime.c
@@ -207,13 +207,13 @@ INPUT_RETURN_VALUE FcitxRimeDoInput(void* arg, FcitxKeySym _sym, unsigned int _s
     FcitxInputState *input = FcitxInstanceGetInputState(rime->owner);
     uint32_t sym = FcitxInputStateGetKeySym(input);
     uint32_t state = FcitxInputStateGetKeyState(input);
-    _state &= (FcitxKeyState_SimpleMask);
+    _state &= (FcitxKeyState_SimpleMask | FcitxKeyState_CapsLock);
 
-    if (_state & (~(FcitxKeyState_Ctrl_Alt_Shift))) {
+    if (_state & (~(FcitxKeyState_Ctrl_Alt_Shift | FcitxKeyState_CapsLock))) {
         return IRV_TO_PROCESS;
     }
 
-    state &= (FcitxKeyState_SimpleMask);
+    state &= (FcitxKeyState_SimpleMask | FcitxKeyState_CapsLock);
 
     return FcitxRimeDoInputReal(arg, sym, state);
 }
@@ -439,4 +439,3 @@ void FcitxRimeToggleDeploy(void* arg)
 
     FcitxRimeUpdateStatus(rime);
 }
-


### PR DESCRIPTION
Chances are that Caps Lock has been turned on even before the IME was loaded.

The following code shows how Rime makes use of bitmask kLockMask (1 << 1), as attached to XK_CapsLock key event, to synchronize IME state with hardware Caps Lock LED state:

https://github.com/lotem/librime/blob/0bf138da08593475a909f14bc9857dd360768a3f/src/gear/ascii_composer.cc#L115
